### PR TITLE
[내 근로 정리] 결과지 저장 및 공유 API 구현

### DIFF
--- a/yourside/src/main/java/com/likelion/yourside/domain/Worksheet.java
+++ b/yourside/src/main/java/com/likelion/yourside/domain/Worksheet.java
@@ -31,4 +31,6 @@ public class Worksheet extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "user_id")
     private User user;
+
+    public void changeIsOpen() {isOpen = true;}
 }

--- a/yourside/src/main/java/com/likelion/yourside/domain/Worksheet.java
+++ b/yourside/src/main/java/com/likelion/yourside/domain/Worksheet.java
@@ -27,10 +27,10 @@ public class Worksheet extends BaseEntity {
     private boolean overtimePay; // 연장 근로 수당 발생 여부
     @Column(name="holiday_pay")
     private boolean holidayPay; // 휴일 근로 수당 발생 여부
-    private boolean isOpen; // 결과지 공개 여부
+    private Boolean isOpen; // 결과지 공개 여부
     @ManyToOne
     @JoinColumn(name = "user_id")
     private User user;
 
-    public void changeIsOpen() {isOpen = true;}
+    public void changeIsOpen() {this.isOpen = true;}
 }

--- a/yourside/src/main/java/com/likelion/yourside/user/service/UserService.java
+++ b/yourside/src/main/java/com/likelion/yourside/user/service/UserService.java
@@ -11,5 +11,4 @@ public interface UserService {
     ResponseEntity<CustomAPIResponse<?>> checkDuplicationUsername(String username); // username 중복 확인
     ResponseEntity<CustomAPIResponse<?>> checkUsername(String name, String email); // username 찾기
     ResponseEntity<CustomAPIResponse<?>> checkPassword(String name, String email, String username); // password 찾기
-
 }

--- a/yourside/src/main/java/com/likelion/yourside/worksheet/controller/WorksheetController.java
+++ b/yourside/src/main/java/com/likelion/yourside/worksheet/controller/WorksheetController.java
@@ -5,10 +5,7 @@ import com.likelion.yourside.worksheet.dto.WorksheetRegisterRequestDto;
 import com.likelion.yourside.worksheet.service.WorksheetService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -19,5 +16,10 @@ public class WorksheetController {
     @PostMapping
     public ResponseEntity<CustomAPIResponse<?>> register(@RequestBody WorksheetRegisterRequestDto worksheetRegisterRequestDto) {
         return worksheetService.register(worksheetRegisterRequestDto);
+    }
+
+    @PutMapping("/{worksheet_id}")
+    public ResponseEntity<CustomAPIResponse<?>> setExpert(@PathVariable("worksheet_id") Long worksheetId) {
+        return worksheetService.setExpert(worksheetId);
     }
 }

--- a/yourside/src/main/java/com/likelion/yourside/worksheet/controller/WorksheetController.java
+++ b/yourside/src/main/java/com/likelion/yourside/worksheet/controller/WorksheetController.java
@@ -19,7 +19,7 @@ public class WorksheetController {
     }
 
     @PutMapping("/{worksheet_id}")
-    public ResponseEntity<CustomAPIResponse<?>> setExpert(@PathVariable("worksheet_id") Long worksheetId) {
-        return worksheetService.setExpert(worksheetId);
+    public ResponseEntity<CustomAPIResponse<?>> share(@PathVariable("worksheet_id") Long worksheetId) {
+        return worksheetService.share(worksheetId);
     }
 }

--- a/yourside/src/main/java/com/likelion/yourside/worksheet/controller/WorksheetController.java
+++ b/yourside/src/main/java/com/likelion/yourside/worksheet/controller/WorksheetController.java
@@ -1,10 +1,12 @@
 package com.likelion.yourside.worksheet.controller;
 
 import com.likelion.yourside.util.response.CustomAPIResponse;
+import com.likelion.yourside.worksheet.dto.WorksheetRegisterRequestDto;
 import com.likelion.yourside.worksheet.service.WorksheetService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -15,7 +17,7 @@ public class WorksheetController {
     private final WorksheetService worksheetService;
 
     @PostMapping
-    public ResponseEntity<CustomAPIResponse<?>> register(WorksheetRegisterRequestDto worksheetRegisterRequestDto) {
+    public ResponseEntity<CustomAPIResponse<?>> register(@RequestBody WorksheetRegisterRequestDto worksheetRegisterRequestDto) {
         return worksheetService.register(worksheetRegisterRequestDto);
     }
 }

--- a/yourside/src/main/java/com/likelion/yourside/worksheet/controller/WorksheetController.java
+++ b/yourside/src/main/java/com/likelion/yourside/worksheet/controller/WorksheetController.java
@@ -1,7 +1,10 @@
 package com.likelion.yourside.worksheet.controller;
 
+import com.likelion.yourside.util.response.CustomAPIResponse;
 import com.likelion.yourside.worksheet.service.WorksheetService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -10,4 +13,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("api/worksheet")
 public class WorksheetController {
     private final WorksheetService worksheetService;
+
+    @PostMapping
+    public ResponseEntity<CustomAPIResponse<?>> register(WorksheetRegisterRequestDto worksheetRegisterRequestDto) {
+        return worksheetService.register(worksheetRegisterRequestDto);
+    }
 }

--- a/yourside/src/main/java/com/likelion/yourside/worksheet/dto/WorksheetRegisterRequestDto.java
+++ b/yourside/src/main/java/com/likelion/yourside/worksheet/dto/WorksheetRegisterRequestDto.java
@@ -19,5 +19,5 @@ public class WorksheetRegisterRequestDto {
     private boolean night_pay;    // 야간 수당
     private boolean overtime_pay; // 연장 근로 수당
     private boolean holiday_pay;  // 휴일 근로 수당
-    private Long userId;
+    private Long user_id;
 }

--- a/yourside/src/main/java/com/likelion/yourside/worksheet/dto/WorksheetRegisterRequestDto.java
+++ b/yourside/src/main/java/com/likelion/yourside/worksheet/dto/WorksheetRegisterRequestDto.java
@@ -1,0 +1,23 @@
+package com.likelion.yourside.worksheet.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+@AllArgsConstructor
+@Builder
+public class WorksheetRegisterRequestDto {
+    private String title;
+    private String content;
+    private int total_pay;
+    private boolean extra_pay;    // 가산 수당
+    private boolean week_pay;     // 주휴 수당
+    private boolean night_pay;    // 야간 수당
+    private boolean overtime_pay; // 연장 근로 수당
+    private boolean holiday_pay;  // 휴일 근로 수당
+    private Long userId;
+}

--- a/yourside/src/main/java/com/likelion/yourside/worksheet/dto/WorksheetRegisterResponseDto.java
+++ b/yourside/src/main/java/com/likelion/yourside/worksheet/dto/WorksheetRegisterResponseDto.java
@@ -1,0 +1,13 @@
+package com.likelion.yourside.worksheet.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+@AllArgsConstructor
+@Builder
+public class WorksheetRegisterResponseDto {
+    private Long worksheet_id;
+}

--- a/yourside/src/main/java/com/likelion/yourside/worksheet/service/WorksheetService.java
+++ b/yourside/src/main/java/com/likelion/yourside/worksheet/service/WorksheetService.java
@@ -1,4 +1,8 @@
 package com.likelion.yourside.worksheet.service;
 
+import com.likelion.yourside.util.response.CustomAPIResponse;
+import org.springframework.http.ResponseEntity;
+
 public interface WorksheetService {
+    ResponseEntity<CustomAPIResponse<?>> register(WorksheetRegisterRequestDto worksheetRegisterRequestDto);
 }

--- a/yourside/src/main/java/com/likelion/yourside/worksheet/service/WorksheetService.java
+++ b/yourside/src/main/java/com/likelion/yourside/worksheet/service/WorksheetService.java
@@ -6,4 +6,5 @@ import org.springframework.http.ResponseEntity;
 
 public interface WorksheetService {
     ResponseEntity<CustomAPIResponse<?>> register(WorksheetRegisterRequestDto worksheetRegisterRequestDto);
+    ResponseEntity<CustomAPIResponse<?>> share(Long worksheetId);
 }

--- a/yourside/src/main/java/com/likelion/yourside/worksheet/service/WorksheetService.java
+++ b/yourside/src/main/java/com/likelion/yourside/worksheet/service/WorksheetService.java
@@ -1,6 +1,7 @@
 package com.likelion.yourside.worksheet.service;
 
 import com.likelion.yourside.util.response.CustomAPIResponse;
+import com.likelion.yourside.worksheet.dto.WorksheetRegisterRequestDto;
 import org.springframework.http.ResponseEntity;
 
 public interface WorksheetService {

--- a/yourside/src/main/java/com/likelion/yourside/worksheet/service/WorksheetServiceImpl.java
+++ b/yourside/src/main/java/com/likelion/yourside/worksheet/service/WorksheetServiceImpl.java
@@ -44,6 +44,7 @@ public class WorksheetServiceImpl implements WorksheetService{
                 .nightPay(worksheetRegisterRequestDto.isNight_pay())
                 .overtimePay(worksheetRegisterRequestDto.isOvertime_pay())
                 .holidayPay(worksheetRegisterRequestDto.isHoliday_pay())
+                .isOpen(false)
                 .user(user)
                 .build();
         worksheetRepository.save(worksheet);
@@ -57,6 +58,30 @@ public class WorksheetServiceImpl implements WorksheetService{
         // 2-3. ResponseEntity
         return ResponseEntity
                 .status(HttpStatus.CREATED)
+                .body(responseBody);
+    }
+    @Override
+    public ResponseEntity<CustomAPIResponse<?>> share(Long worksheetId) {
+        // 1. worksheet 있는지 조회
+        Optional<Worksheet> foundWorksheet = worksheetRepository.findById(worksheetId);
+        if (foundWorksheet.isEmpty()) {
+            // 1-1. data
+            // 1-2. response body
+            CustomAPIResponse<Object> responseBody = CustomAPIResponse.createFailWithoutData(HttpStatus.NOT_FOUND.value(), "일치하는 결과 근로지가 없습니다.");
+            // 1-3. Response Entity
+            return ResponseEntity
+                    .status(HttpStatus.NOT_FOUND)
+                    .body(responseBody);
+        }
+        // 2. isOpen 변경
+        Worksheet worksheet = foundWorksheet.get();
+        worksheet.changeIsOpen();
+        // 2-1. data
+        // 2-2. response Body
+        CustomAPIResponse<Object> responseBody = CustomAPIResponse.createSuccessWithoutData(HttpStatus.OK.value(), "공유되었습니다.");
+        // 2-3. ResponseEntity
+        return ResponseEntity
+                .status(HttpStatus.OK)
                 .body(responseBody);
     }
 }

--- a/yourside/src/main/java/com/likelion/yourside/worksheet/service/WorksheetServiceImpl.java
+++ b/yourside/src/main/java/com/likelion/yourside/worksheet/service/WorksheetServiceImpl.java
@@ -1,6 +1,7 @@
 package com.likelion.yourside.worksheet.service;
 
 import com.likelion.yourside.util.response.CustomAPIResponse;
+import com.likelion.yourside.worksheet.dto.WorksheetRegisterRequestDto;
 import com.likelion.yourside.worksheet.repository.WorksheetRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/yourside/src/main/java/com/likelion/yourside/worksheet/service/WorksheetServiceImpl.java
+++ b/yourside/src/main/java/com/likelion/yourside/worksheet/service/WorksheetServiceImpl.java
@@ -1,11 +1,18 @@
 package com.likelion.yourside.worksheet.service;
 
+import com.likelion.yourside.util.response.CustomAPIResponse;
 import com.likelion.yourside.worksheet.repository.WorksheetRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class WorksheetServiceImpl implements WorksheetService{
     private final WorksheetRepository worksheetRepository;
+
+    @Override
+    public ResponseEntity<CustomAPIResponse<?>> register(WorksheetRegisterRequestDto worksheetRegisterRequestDto) {
+        return null;
+    }
 }

--- a/yourside/src/main/java/com/likelion/yourside/worksheet/service/WorksheetServiceImpl.java
+++ b/yourside/src/main/java/com/likelion/yourside/worksheet/service/WorksheetServiceImpl.java
@@ -76,6 +76,7 @@ public class WorksheetServiceImpl implements WorksheetService{
         // 2. isOpen 변경
         Worksheet worksheet = foundWorksheet.get();
         worksheet.changeIsOpen();
+        worksheetRepository.save(worksheet);
         // 2-1. data
         // 2-2. response Body
         CustomAPIResponse<Object> responseBody = CustomAPIResponse.createSuccessWithoutData(HttpStatus.OK.value(), "공유되었습니다.");

--- a/yourside/src/main/java/com/likelion/yourside/worksheet/service/WorksheetServiceImpl.java
+++ b/yourside/src/main/java/com/likelion/yourside/worksheet/service/WorksheetServiceImpl.java
@@ -1,19 +1,62 @@
 package com.likelion.yourside.worksheet.service;
 
+import com.likelion.yourside.domain.User;
+import com.likelion.yourside.domain.Worksheet;
+import com.likelion.yourside.user.repository.UserRepository;
 import com.likelion.yourside.util.response.CustomAPIResponse;
 import com.likelion.yourside.worksheet.dto.WorksheetRegisterRequestDto;
+import com.likelion.yourside.worksheet.dto.WorksheetRegisterResponseDto;
 import com.likelion.yourside.worksheet.repository.WorksheetRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class WorksheetServiceImpl implements WorksheetService{
     private final WorksheetRepository worksheetRepository;
+    private final UserRepository userRepository;
 
     @Override
     public ResponseEntity<CustomAPIResponse<?>> register(WorksheetRegisterRequestDto worksheetRegisterRequestDto) {
-        return null;
+        // 1. userId에 해당하는 유저 있는지 확인
+        Optional<User> foundUser = userRepository.findById(worksheetRegisterRequestDto.getUser_id());
+        if (foundUser.isEmpty()) {
+            // 1-1. data
+            // 1-2. responseBody
+            CustomAPIResponse<Object> responseBody = CustomAPIResponse.createFailWithoutData(HttpStatus.NOT_FOUND.value(), "존재하지 않는 사용자입니다.");
+            // 1-3. ResponseEntity
+            return ResponseEntity
+                    .status(HttpStatus.NOT_FOUND)
+                    .body(responseBody);
+        }
+        // 2. 내 근로 결과지 저장
+        User user = foundUser.get();
+        Worksheet worksheet = Worksheet.builder()
+                .title(worksheetRegisterRequestDto.getTitle())
+                .content(worksheetRegisterRequestDto.getContent())
+                .totalPay(worksheetRegisterRequestDto.getTotal_pay())
+                .extraPay(worksheetRegisterRequestDto.isExtra_pay())
+                .weekPay(worksheetRegisterRequestDto.isWeek_pay())
+                .nightPay(worksheetRegisterRequestDto.isNight_pay())
+                .overtimePay(worksheetRegisterRequestDto.isOvertime_pay())
+                .holidayPay(worksheetRegisterRequestDto.isHoliday_pay())
+                .user(user)
+                .build();
+        worksheetRepository.save(worksheet);
+        // 2-1. data
+        Long id = worksheet.getId();
+        WorksheetRegisterResponseDto data = WorksheetRegisterResponseDto.builder()
+                .worksheet_id(id)
+                .build();
+        // 2-2. responseBody
+        CustomAPIResponse<WorksheetRegisterResponseDto> responseBody = CustomAPIResponse.createSuccess(HttpStatus.CREATED.value(), data, "근로지 생성 완료되었습니다.");
+        // 2-3. ResponseEntity
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(responseBody);
     }
 }


### PR DESCRIPTION
### 🌈 Issue 번호
- close #28 

### 📄 변경 사항
1. 결과지 저장 및 공유 API 구현
2. 결과지 저장 및 공유 API 구현 Test

### 🏆 테스트 결과
#### 결과지 저장
##### 성공(201)
<img width="624" alt="image" src="https://github.com/HSU-Likelion12-yourSide/YourSide-Server/assets/77336664/7af436c2-9028-4774-8241-5dac4e01e29b">

##### 존재하지 않는 사용자(404)
<img width="630" alt="image" src="https://github.com/HSU-Likelion12-yourSide/YourSide-Server/assets/77336664/7139e63f-e630-4fbc-a080-7920cad0a803">

#### 결과지 공유
##### 성공(200)
<img width="640" alt="image" src="https://github.com/HSU-Likelion12-yourSide/YourSide-Server/assets/77336664/d1cb0f4c-267b-410e-836c-6e39971fe794">

##### 존재하지 않는 결과지(404)
<img width="639" alt="image" src="https://github.com/HSU-Likelion12-yourSide/YourSide-Server/assets/77336664/bca7a507-4d05-4704-96fa-0160c49622d4">

