### PR TITLE
[ 마이페이지 ] 유저 정보 조회 & 노무사 인증 API

### DIFF
--- a/yourside/src/main/java/com/likelion/yourside/domain/User.java
+++ b/yourside/src/main/java/com/likelion/yourside/domain/User.java
@@ -20,4 +20,6 @@ public class User extends BaseEntity {
     private String nickname; // 별명
     @Column(name="is_expert")
     private boolean isExpert; // "노무사" 자격 유무
+
+    public void changeIsExpert() {this.isExpert = true;}
 }

--- a/yourside/src/main/java/com/likelion/yourside/myPage/controller/MypageController.java
+++ b/yourside/src/main/java/com/likelion/yourside/myPage/controller/MypageController.java
@@ -1,7 +1,11 @@
 package com.likelion.yourside.myPage.controller;
 
 import com.likelion.yourside.myPage.service.MypageService;
+import com.likelion.yourside.util.response.CustomAPIResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -10,4 +14,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class MypageController {
     private final MypageService mypageService;
+
+    @GetMapping("/{user_id}")
+    public ResponseEntity<CustomAPIResponse<?>> getUserInfo(@PathVariable("user_id") Long userId) {
+        return mypageService.getUserInfo(userId);
+    }
 }

--- a/yourside/src/main/java/com/likelion/yourside/myPage/controller/MypageController.java
+++ b/yourside/src/main/java/com/likelion/yourside/myPage/controller/MypageController.java
@@ -1,0 +1,13 @@
+package com.likelion.yourside.myPage.controller;
+
+import com.likelion.yourside.myPage.service.MypageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/mypage")
+@RequiredArgsConstructor
+public class MypageController {
+    private final MypageService mypageService;
+}

--- a/yourside/src/main/java/com/likelion/yourside/myPage/controller/MypageController.java
+++ b/yourside/src/main/java/com/likelion/yourside/myPage/controller/MypageController.java
@@ -4,10 +4,7 @@ import com.likelion.yourside.myPage.service.MypageService;
 import com.likelion.yourside.util.response.CustomAPIResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("api/mypage")
@@ -18,5 +15,10 @@ public class MypageController {
     @GetMapping("/{user_id}")
     public ResponseEntity<CustomAPIResponse<?>> getUserInfo(@PathVariable("user_id") Long userId) {
         return mypageService.getUserInfo(userId);
+    }
+
+    @PutMapping("/{user_id}")
+    public ResponseEntity<CustomAPIResponse<?>> updateUserIsExpert(@PathVariable("user_id") Long userId) {
+        return mypageService.updateUserIsExpert(userId);
     }
 }

--- a/yourside/src/main/java/com/likelion/yourside/myPage/dto/MypageGetuserinfoResponseDto.java
+++ b/yourside/src/main/java/com/likelion/yourside/myPage/dto/MypageGetuserinfoResponseDto.java
@@ -1,0 +1,20 @@
+package com.likelion.yourside.myPage.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+@AllArgsConstructor
+@Builder
+public class MypageGetuserinfoResponseDto {
+    @JsonProperty("worksheet_count")
+    private int worksheetCount;
+    @JsonProperty("posting_count")
+    private int postingCount;
+    @JsonProperty("comment_count")
+    private int commentCount;
+    private String nickname;
+}

--- a/yourside/src/main/java/com/likelion/yourside/myPage/service/MypageService.java
+++ b/yourside/src/main/java/com/likelion/yourside/myPage/service/MypageService.java
@@ -1,4 +1,8 @@
 package com.likelion.yourside.myPage.service;
 
+import com.likelion.yourside.util.response.CustomAPIResponse;
+import org.springframework.http.ResponseEntity;
+
 public interface MypageService {
+    ResponseEntity<CustomAPIResponse<?>> getUserInfo(Long userId);
 }

--- a/yourside/src/main/java/com/likelion/yourside/myPage/service/MypageService.java
+++ b/yourside/src/main/java/com/likelion/yourside/myPage/service/MypageService.java
@@ -5,4 +5,5 @@ import org.springframework.http.ResponseEntity;
 
 public interface MypageService {
     ResponseEntity<CustomAPIResponse<?>> getUserInfo(Long userId);
+    ResponseEntity<CustomAPIResponse<?>> updateUserIsExpert(Long userId);
 }

--- a/yourside/src/main/java/com/likelion/yourside/myPage/service/MypageService.java
+++ b/yourside/src/main/java/com/likelion/yourside/myPage/service/MypageService.java
@@ -1,0 +1,4 @@
+package com.likelion.yourside.myPage.service;
+
+public interface MypageService {
+}

--- a/yourside/src/main/java/com/likelion/yourside/myPage/service/MypageServiceImpl.java
+++ b/yourside/src/main/java/com/likelion/yourside/myPage/service/MypageServiceImpl.java
@@ -1,0 +1,9 @@
+package com.likelion.yourside.myPage.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MypageServiceImpl implements MypageService{
+}

--- a/yourside/src/main/java/com/likelion/yourside/myPage/service/MypageServiceImpl.java
+++ b/yourside/src/main/java/com/likelion/yourside/myPage/service/MypageServiceImpl.java
@@ -59,7 +59,6 @@ public class MypageServiceImpl implements MypageService{
                 .status(HttpStatus.OK)
                 .body(responseBody);
     }
-
     @Override
     public ResponseEntity<CustomAPIResponse<?>> updateUserIsExpert(Long userId) {
         // 1. user 존재하는지 조회

--- a/yourside/src/main/java/com/likelion/yourside/myPage/service/MypageServiceImpl.java
+++ b/yourside/src/main/java/com/likelion/yourside/myPage/service/MypageServiceImpl.java
@@ -3,6 +3,7 @@ package com.likelion.yourside.myPage.service;
 import com.likelion.yourside.domain.Posting;
 import com.likelion.yourside.domain.User;
 import com.likelion.yourside.domain.Worksheet;
+import com.likelion.yourside.myPage.dto.MypageGetuserinfoResponseDto;
 import com.likelion.yourside.posting.repository.PostingRepository;
 import com.likelion.yourside.user.repository.UserRepository;
 import com.likelion.yourside.util.response.CustomAPIResponse;
@@ -43,6 +44,19 @@ public class MypageServiceImpl implements MypageService{
         int postingCount = postingList.size();
         // 4. 답변 개수 조회
         int commentCount = 0;
-        return null;
+        // 5. 응답
+        // 5-1. data
+        MypageGetuserinfoResponseDto data = MypageGetuserinfoResponseDto.builder()
+                .worksheetCount(worksheetCount)
+                .postingCount(postingCount)
+                .commentCount(commentCount)
+                .nickname(user.getNickname())
+                .build();
+        // 5-2. responseBody
+        CustomAPIResponse<MypageGetuserinfoResponseDto> responseBody = CustomAPIResponse.createSuccess(HttpStatus.OK.value(), data, "사용자 정보 조회 완료되었습니다.");
+        // 5-3. ResponseEntity
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(responseBody);
     }
 }

--- a/yourside/src/main/java/com/likelion/yourside/myPage/service/MypageServiceImpl.java
+++ b/yourside/src/main/java/com/likelion/yourside/myPage/service/MypageServiceImpl.java
@@ -1,9 +1,48 @@
 package com.likelion.yourside.myPage.service;
 
+import com.likelion.yourside.domain.Posting;
+import com.likelion.yourside.domain.User;
+import com.likelion.yourside.domain.Worksheet;
+import com.likelion.yourside.posting.repository.PostingRepository;
+import com.likelion.yourside.user.repository.UserRepository;
+import com.likelion.yourside.util.response.CustomAPIResponse;
+import com.likelion.yourside.worksheet.repository.WorksheetRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class MypageServiceImpl implements MypageService{
+    private final UserRepository userRepository;
+    private final WorksheetRepository worksheetRepository;
+    private final PostingRepository postingRepository;
+    @Override
+    public ResponseEntity<CustomAPIResponse<?>> getUserInfo(Long userId) {
+        // 1. user 존재하는지 조회
+        Optional<User> foundUser = userRepository.findById(userId);
+        if (foundUser.isEmpty()) {
+            // 1-1. data
+            // 1-2. responseBody
+            CustomAPIResponse<Object> responseBody = CustomAPIResponse.createFailWithoutData(HttpStatus.NOT_FOUND.value(), "사용자가 존재하지 않습니다.");
+            // 1-3. ResponseEntity
+            return ResponseEntity
+                    .status(HttpStatus.NOT_FOUND)
+                    .body(responseBody);
+        }
+        User user = foundUser.get();
+        // 2. 근로 결과지 개수 조회
+        List<Worksheet> worksheetList = worksheetRepository.finAllByUser(user);
+        int worksheetCount = worksheetList.size();
+        // 3. 네편 현답 개수 조회
+        List<Posting> postingList = postingRepository.findALlByUser(user);
+        int postingCount = postingList.size();
+        // 4. 답변 개수 조회
+        int commentCount = 0;
+        return null;
+    }
 }

--- a/yourside/src/main/java/com/likelion/yourside/myPage/service/MypageServiceImpl.java
+++ b/yourside/src/main/java/com/likelion/yourside/myPage/service/MypageServiceImpl.java
@@ -59,4 +59,31 @@ public class MypageServiceImpl implements MypageService{
                 .status(HttpStatus.OK)
                 .body(responseBody);
     }
+
+    @Override
+    public ResponseEntity<CustomAPIResponse<?>> updateUserIsExpert(Long userId) {
+        // 1. user 존재하는지 조회
+        Optional<User> foundUser = userRepository.findById(userId);
+        if (foundUser.isEmpty()) {
+            // 1-1. data
+            // 1-2. responseBody
+            CustomAPIResponse<Object> responseBody = CustomAPIResponse.createFailWithoutData(HttpStatus.NOT_FOUND.value(), "존재하지 않는 사용자입니다.");
+            // 1-3. ResponseEntity
+            return ResponseEntity
+                    .status(HttpStatus.NOT_FOUND)
+                    .body(responseBody);
+        }
+        // 2. isExpert -> true로 수정
+        User user = foundUser.get();
+        user.changeIsExpert();
+        userRepository.save(user);
+        // 3. 응답
+        // 3-1. data
+        // 3-2. responseBody
+        CustomAPIResponse<Object> responseBody = CustomAPIResponse.createSuccessWithoutData(HttpStatus.OK.value(), "노무사 인증이 완료되었습니다.");
+        // 3-3. ResponseEntity
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(responseBody);
+    }
 }

--- a/yourside/src/main/java/com/likelion/yourside/posting/repository/PostingRepository.java
+++ b/yourside/src/main/java/com/likelion/yourside/posting/repository/PostingRepository.java
@@ -1,0 +1,15 @@
+package com.likelion.yourside.posting.repository;
+
+import com.likelion.yourside.domain.Posting;
+import com.likelion.yourside.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface PostingRepository extends JpaRepository<Posting, Long> {
+    @Query("select p from Posting p where p.user = :user")
+    List<Posting> findALlByUser(User user);
+}

--- a/yourside/src/main/java/com/likelion/yourside/worksheet/repository/WorksheetRepository.java
+++ b/yourside/src/main/java/com/likelion/yourside/worksheet/repository/WorksheetRepository.java
@@ -1,5 +1,6 @@
 package com.likelion.yourside.worksheet.repository;
 
+import com.likelion.yourside.domain.User;
 import com.likelion.yourside.domain.Worksheet;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -11,4 +12,7 @@ import java.util.List;
 public interface WorksheetRepository extends JpaRepository<Worksheet, Long> {
     @Query("select w from Worksheet w where w.isOpen = true ")
     List<Worksheet> findAllbyIsOpen();
+
+    @Query("select w from Worksheet w where w.user = :user")
+    List<Worksheet> finAllByUser(User user);
 }


### PR DESCRIPTION
### 🌈 Issue 번호
- close #51 

### 📄 변경 사항
1. 유저 정보 조회 & 노무사 인증 API
2. 유저 정보 조회 & 노무사 인증 API Test

### 🏆 테스트 결과
#### 유저 정보 조회 API
##### 200(성공)
<img width="522" alt="image" src="https://github.com/HSU-Likelion12-yourSide/YourSide-Server/assets/77336664/3bb1840e-e880-4cdb-bb50-43286bcad73e">

##### 404(존재하지 않는 유저)
<img width="529" alt="image" src="https://github.com/HSU-Likelion12-yourSide/YourSide-Server/assets/77336664/d0893b83-09e2-4dc1-9205-d2cc61884514">

#### 노무사 인증 API
##### 200(성공)
<img width="517" alt="image" src="https://github.com/HSU-Likelion12-yourSide/YourSide-Server/assets/77336664/17f4476f-361f-4032-9724-8795fb753232">

##### 404(존재하지 않는 유저)
<img width="524" alt="image" src="https://github.com/HSU-Likelion12-yourSide/YourSide-Server/assets/77336664/efb762e9-fce4-4d80-8ac5-10c9b00c469c">

