### PR TITLE
✨ Comment API 구현 2 (댓글에 좋아요 추가/삭제)

### DIFF
--- a/yourside/src/main/java/com/likelion/yourside/comment/controller/CommentController.java
+++ b/yourside/src/main/java/com/likelion/yourside/comment/controller/CommentController.java
@@ -1,6 +1,7 @@
 package com.likelion.yourside.comment.controller;
 
 import com.likelion.yourside.comment.dto.CommentCreateDto;
+import com.likelion.yourside.comment.dto.CommentLikeDto;
 import com.likelion.yourside.comment.service.CommentService;
 import com.likelion.yourside.util.response.CustomAPIResponse;
 import lombok.RequiredArgsConstructor;
@@ -21,8 +22,7 @@ public class CommentController {
     @PostMapping("/{posting_id}")
     public ResponseEntity<CustomAPIResponse<?>> createComment(
             @PathVariable("posting_id") Long postingId,
-            @RequestBody CommentCreateDto.Req req
-    ){
+            @RequestBody CommentCreateDto.Req req) {
         ResponseEntity<CustomAPIResponse<?>> result = commentService.createComment(postingId, req);
         return result;
     }
@@ -30,9 +30,24 @@ public class CommentController {
     //댓글 전체 조회
     @GetMapping("/{posting_id}/list")
     public ResponseEntity<CustomAPIResponse<?>> getAllComment(
-            @PathVariable("posting_id") Long postingId
-    ){
+            @PathVariable("posting_id") Long postingId) {
         ResponseEntity<CustomAPIResponse<?>> result = commentService.getAllComment(postingId);
+        return result;
+    }
+
+    //댓글에 좋아요 추가
+    @PostMapping("/likes")
+    public ResponseEntity<CustomAPIResponse<?>> addLikes(
+            @RequestBody CommentLikeDto.Req req) {
+        ResponseEntity<CustomAPIResponse<?>> result = commentService.addLikeToComment(req);
+        return result;
+    }
+
+    //댓글에 좋아요 해제
+    @DeleteMapping("/likes")
+    public ResponseEntity<CustomAPIResponse<?>> removeLikes(
+            @RequestBody CommentLikeDto.Req req) {
+        ResponseEntity<CustomAPIResponse<?>> result = commentService.removeLikeFromComment(req);
         return result;
     }
 }

--- a/yourside/src/main/java/com/likelion/yourside/comment/dto/CommentLikeDto.java
+++ b/yourside/src/main/java/com/likelion/yourside/comment/dto/CommentLikeDto.java
@@ -1,0 +1,29 @@
+package com.likelion.yourside.comment.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.likelion.yourside.domain.Comment;
+import com.likelion.yourside.domain.Likes;
+import com.likelion.yourside.domain.User;
+import lombok.*;
+
+public class CommentLikeDto {
+    @Getter
+    @Setter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class Req {
+        @JsonProperty("user_id")
+        private Long userId; //사용자 ID
+        @JsonProperty("comment_id")
+        private Long commentId; //댓글 ID
+
+        public Likes toEntity(User user, Comment comment){
+            return Likes.builder()
+                    .user(user)
+                    .comment(comment)
+                    .build();
+
+        }
+    }
+}

--- a/yourside/src/main/java/com/likelion/yourside/comment/repository/CommentRepository.java
+++ b/yourside/src/main/java/com/likelion/yourside/comment/repository/CommentRepository.java
@@ -1,9 +1,15 @@
 package com.likelion.yourside.comment.repository;
 
 import com.likelion.yourside.domain.Comment;
+import com.likelion.yourside.domain.Posting;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+    @Query("select c from Comment c where c.posting = :posting")
+    List<Comment> findAllbyPosting(Posting posting);
 }

--- a/yourside/src/main/java/com/likelion/yourside/comment/service/CommentService.java
+++ b/yourside/src/main/java/com/likelion/yourside/comment/service/CommentService.java
@@ -1,6 +1,7 @@
 package com.likelion.yourside.comment.service;
 
 import com.likelion.yourside.comment.dto.CommentCreateDto;
+import com.likelion.yourside.comment.dto.CommentLikeDto;
 import com.likelion.yourside.util.response.CustomAPIResponse;
 import org.springframework.http.ResponseEntity;
 
@@ -11,4 +12,11 @@ public interface CommentService {
     //데이터베이스에 저장되어 있는 해당 게시글의 댓글 정보 얻어오기
     ResponseEntity<CustomAPIResponse<?>> getAllComment(Long postingId);
 
+    //1. likes 스키마에 user_id, comment_id를 가지는 레코드 추가
+    //2. Comment 스키마에 likes_count +1
+    ResponseEntity<CustomAPIResponse<?>> addLikeToComment(CommentLikeDto.Req req);
+
+    //1. likes 스키마에 user_id, comment_id를 가지는 레코드 삭제
+    //2. Comment 스키마에 likes_count -1
+    ResponseEntity<CustomAPIResponse<?>> removeLikeFromComment(CommentLikeDto.Req req);
 }

--- a/yourside/src/main/java/com/likelion/yourside/domain/Comment.java
+++ b/yourside/src/main/java/com/likelion/yourside/domain/Comment.java
@@ -14,6 +14,7 @@ public class Comment extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id; // PK
     private String content; // 내용
+    // @JoinColumn(name = "likes_count") 수정하면 좋을 듯
     private int likes; // 좋아요 수
     @ManyToOne
     @JoinColumn(name = "user_id")
@@ -21,4 +22,8 @@ public class Comment extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "posting_id")
     private Posting posting;
+
+    public void changeLikes(int likes) {
+        this.likes = likes;
+    }
 }

--- a/yourside/src/main/java/com/likelion/yourside/likes/repository/LikesRepository.java
+++ b/yourside/src/main/java/com/likelion/yourside/likes/repository/LikesRepository.java
@@ -1,13 +1,20 @@
 package com.likelion.yourside.likes.repository;
 
+import com.likelion.yourside.domain.Comment;
 import com.likelion.yourside.domain.Likes;
+import com.likelion.yourside.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface LikesRepository extends JpaRepository<Likes, Long> {
     @Query("SELECT CASE WHEN COUNT(l) > 0 THEN true ELSE false END FROM Likes l WHERE l.user.id = :userId AND l.comment.id = :commentId")
     boolean existsByUserIdAndCommentId(@Param("userId") Long userId, @Param("commentId") Long commentId);
+
+    Optional<Likes> findByUserAndComment(User user, Comment comment);
+
 }


### PR DESCRIPTION
### 🌈 Issue 번호
- close #43 

### 📄 변경 사항
Comment API 구현 2 (댓글에 좋아요 추가/삭제)

추가로 개발하는 도중 알게 된 여러 오류 수정 

- @JsonProperty 추가
- List<Comment> comments = commentRepository.findbyId(commentId); -> List<Comment> comments = commentRepository.findAllbyPosting(posting);
- 전체 댓글 조회에서 comment 테이블의 모든 값을 가져오는 것이 아닌 commment 테이블의 레코드들 중 posting이 해당 postingId인 레코드만 가져오도록 수정
- 
### 🏆 테스트 결과
ex) API의 경우 명세서에 기재된 사항들 Postman으로 테스트한 결과 첨부
1.  좋아요 추가
- 200(성공)
![image](https://github.com/HSU-Likelion12-yourSide/YourSide-Server/assets/147326233/7f2a016f-ced8-4a35-859f-22e12adbd165)

- 404(찾을 수 없음)
![image](https://github.com/HSU-Likelion12-yourSide/YourSide-Server/assets/147326233/b857a2ec-5f21-481f-b2d7-9cb2674d0b78)

2. 좋아요 취소
- 200(성공)
![image](https://github.com/HSU-Likelion12-yourSide/YourSide-Server/assets/147326233/ffa644e8-dfd8-41d9-8670-fa7fdb552a0a)
- 404(해당 댓글에 좋아요를 누른 적 없는 경우)
![image](https://github.com/HSU-Likelion12-yourSide/YourSide-Server/assets/147326233/cf16f3c0-7c0e-48f9-9965-2c9b2619acde)


- 404(댓글을 찾을 수 없는 경우)
![image](https://github.com/HSU-Likelion12-yourSide/YourSide-Server/assets/147326233/180709b2-7e7f-45c0-9ad9-1ea5a046fab3)


--> 상태코드 잘못 표기한 오류 수정하겠습니다
