### PR TITLE
✨ 댓글 싫어요 추가 API 개발 & 댓글 작성 부분 수정 

### DIFF
--- a/yourside/src/main/java/com/likelion/yourside/comment/controller/CommentController.java
+++ b/yourside/src/main/java/com/likelion/yourside/comment/controller/CommentController.java
@@ -1,6 +1,7 @@
 package com.likelion.yourside.comment.controller;
 
 import com.likelion.yourside.comment.dto.CommentCreateDto;
+import com.likelion.yourside.comment.dto.CommentDislikeDto;
 import com.likelion.yourside.comment.dto.CommentLikeDto;
 import com.likelion.yourside.comment.service.CommentService;
 import com.likelion.yourside.util.response.CustomAPIResponse;
@@ -19,11 +20,10 @@ public class CommentController {
     private final CommentService commentService;
 
     //댓글 작성
-    @PostMapping("/{posting_id}")
+    @PostMapping
     public ResponseEntity<CustomAPIResponse<?>> createComment(
-            @PathVariable("posting_id") Long postingId,
             @RequestBody CommentCreateDto.Req req) {
-        ResponseEntity<CustomAPIResponse<?>> result = commentService.createComment(postingId, req);
+        ResponseEntity<CustomAPIResponse<?>> result = commentService.createComment(req);
         return result;
     }
 
@@ -48,6 +48,14 @@ public class CommentController {
     public ResponseEntity<CustomAPIResponse<?>> removeLikes(
             @RequestBody CommentLikeDto.Req req) {
         ResponseEntity<CustomAPIResponse<?>> result = commentService.removeLikeFromComment(req);
+        return result;
+    }
+
+    //댓글에 싫어요 추가
+    @PostMapping("/dislikes")
+    public ResponseEntity<CustomAPIResponse<?>> addDislikes(
+            @RequestBody CommentDislikeDto.Req req) {
+        ResponseEntity<CustomAPIResponse<?>> result = commentService.addDislikeToComment(req);
         return result;
     }
 }

--- a/yourside/src/main/java/com/likelion/yourside/comment/dto/CommentDislikeDto.java
+++ b/yourside/src/main/java/com/likelion/yourside/comment/dto/CommentDislikeDto.java
@@ -1,0 +1,30 @@
+package com.likelion.yourside.comment.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.likelion.yourside.domain.Comment;
+import com.likelion.yourside.domain.Dislikes;
+import com.likelion.yourside.domain.Likes;
+import com.likelion.yourside.domain.User;
+import lombok.*;
+
+public class CommentDislikeDto {
+    @Getter
+    @Setter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class Req {
+        @JsonProperty("user_id")
+        private Long userId; //사용자 ID
+        @JsonProperty("comment_id")
+        private Long commentId; //댓글 ID
+
+        public Dislikes toEntity(User user, Comment comment){
+            return Dislikes.builder()
+                    .user(user)
+                    .comment(comment)
+                    .build();
+
+        }
+    }
+}

--- a/yourside/src/main/java/com/likelion/yourside/comment/service/CommentService.java
+++ b/yourside/src/main/java/com/likelion/yourside/comment/service/CommentService.java
@@ -1,22 +1,15 @@
 package com.likelion.yourside.comment.service;
 
 import com.likelion.yourside.comment.dto.CommentCreateDto;
+import com.likelion.yourside.comment.dto.CommentDislikeDto;
 import com.likelion.yourside.comment.dto.CommentLikeDto;
 import com.likelion.yourside.util.response.CustomAPIResponse;
 import org.springframework.http.ResponseEntity;
 
 public interface CommentService {
-    //댓글 데이터베이스에 추가하기
-    ResponseEntity<CustomAPIResponse<?>> createComment(Long postingId, CommentCreateDto.Req req);
-
-    //데이터베이스에 저장되어 있는 해당 게시글의 댓글 정보 얻어오기
+    ResponseEntity<CustomAPIResponse<?>> createComment(CommentCreateDto.Req req);
     ResponseEntity<CustomAPIResponse<?>> getAllComment(Long postingId);
-
-    //1. likes 스키마에 user_id, comment_id를 가지는 레코드 추가
-    //2. Comment 스키마에 likes_count +1
     ResponseEntity<CustomAPIResponse<?>> addLikeToComment(CommentLikeDto.Req req);
-
-    //1. likes 스키마에 user_id, comment_id를 가지는 레코드 삭제
-    //2. Comment 스키마에 likes_count -1
     ResponseEntity<CustomAPIResponse<?>> removeLikeFromComment(CommentLikeDto.Req req);
+    ResponseEntity<CustomAPIResponse<?>> addDislikeToComment(CommentDislikeDto.Req req);
 }

--- a/yourside/src/main/java/com/likelion/yourside/comment/service/CommentServiceImpl.java
+++ b/yourside/src/main/java/com/likelion/yourside/comment/service/CommentServiceImpl.java
@@ -1,12 +1,11 @@
 package com.likelion.yourside.comment.service;
 import com.likelion.yourside.comment.dto.CommentCreateDto;
+import com.likelion.yourside.comment.dto.CommentDislikeDto;
 import com.likelion.yourside.comment.dto.CommentLikeDto;
 import com.likelion.yourside.comment.dto.CommentListDto;
 import com.likelion.yourside.comment.repository.CommentRepository;
-import com.likelion.yourside.domain.Comment;
-import com.likelion.yourside.domain.Likes;
-import com.likelion.yourside.domain.Posting;
-import com.likelion.yourside.domain.User;
+import com.likelion.yourside.dislikes.DislikesRepository;
+import com.likelion.yourside.domain.*;
 import com.likelion.yourside.likes.repository.LikesRepository;
 import com.likelion.yourside.posting.repository.PostingRepository;
 import com.likelion.yourside.user.repository.UserRepository;
@@ -29,13 +28,14 @@ public class CommentServiceImpl implements CommentService{
     private final UserRepository userRepository;
     private final PostingRepository postingRepository;
     private final LikesRepository likesRepository;
+    private final DislikesRepository dislikesRepository;
 
-    //댓글 작성 -----------------------------------------------------------------------------------------------
+    //댓글 작성 -------------------------------------------------------------------------------------------------------------------------------------
     @Override
-    public ResponseEntity<CustomAPIResponse<?>> createComment(Long postingId, @Valid CommentCreateDto.Req req) {
+    public ResponseEntity<CustomAPIResponse<?>> createComment(CommentCreateDto.Req req) {
         User user = userRepository.findById(req.getUser_id()).orElseThrow();
 
-        Optional<Posting> optionalPosting = postingRepository.findById(postingId);
+        Optional<Posting> optionalPosting = postingRepository.findById(req.getPosting_id());
         //해당 게시글이 없는 경우 : 404
         if (optionalPosting.isEmpty()) {
             return ResponseEntity
@@ -46,7 +46,7 @@ public class CommentServiceImpl implements CommentService{
 
         //Comment 엔티티 객체 생성 후 저장
         Comment comment = req.toEntity(posting,req, user);
-        Comment savedComment = commentRepository.save(comment);
+        commentRepository.save(comment);
 
         //댓글 작성 성공 : 201
         CustomAPIResponse<?> res = CustomAPIResponse.createSuccessWithoutData(HttpStatus.CREATED.value(),  "댓글이 작성되었습니다.");
@@ -54,7 +54,7 @@ public class CommentServiceImpl implements CommentService{
     }
 
 
-    //댓글 전체 조회 -------------------------------------------------------------------------------------------
+    //댓글 전체 조회 ---------------------------------------------------------------------------------------------------------------------------------
     @Override
     public ResponseEntity<CustomAPIResponse<?>> getAllComment(Long postingId) {
         Optional<Posting> optionalPosting = postingRepository.findById(postingId);
@@ -99,7 +99,8 @@ public class CommentServiceImpl implements CommentService{
                 .body(res);
     }
 
-    //좋아요 추가--------------------------------------------------------------------------------------
+
+    //좋아요 추가------------------------------------------------------------------------------------------------------------------------------------
     @Override
     public ResponseEntity<CustomAPIResponse<?>> addLikeToComment(CommentLikeDto.Req req) {
         // DTO 검증 : API에는 없음(프론트 측에서 해서 줄 것. 그러나 이미 만들었으니 통신할 때 편하라고 남겨둠)
@@ -134,7 +135,8 @@ public class CommentServiceImpl implements CommentService{
         return ResponseEntity.ok(res);
     }
 
-    //좋아요 취소--------------------------------------------------------------------------------------
+
+    //좋아요 취소--------------------------------------------------------------------------------------------------------------------------------------
     @Override
     public ResponseEntity<CustomAPIResponse<?>> removeLikeFromComment(CommentLikeDto.Req req) {
 
@@ -175,6 +177,42 @@ public class CommentServiceImpl implements CommentService{
 
         //좋아요 삭제 성공 : 200
         CustomAPIResponse<?> res = CustomAPIResponse.createSuccessWithoutData(HttpStatus.OK.value(), "해당 댓글에 좋아요를 취소하셨습니다.");
+        return ResponseEntity.ok(res);
+    }
+
+
+    //싫어요 추가 ------------------------------------------------------------------------------------------------------------------------------------
+    @Override
+    public ResponseEntity<CustomAPIResponse<?>> addDislikeToComment(CommentDislikeDto.Req req) {
+        // DTO 검증 : API에는 없음(프론트 측에서 해서 줄 것. 그러나 이미 만들었으니 통신할 때 편하라고 남겨둠)
+        if (req.getUserId() == null || req.getCommentId() == null) {
+            return ResponseEntity
+                    .status(HttpStatus.BAD_REQUEST)
+                    .body(CustomAPIResponse.createFailWithoutData(HttpStatus.BAD_REQUEST.value(), "user_id와 comment_id는 필수 값입니다."));
+        }
+
+        //DB에 해당 댓글이 없는 경우 : 404
+        Optional<Comment> optionalComment = commentRepository.findById(req.getCommentId());
+        if (optionalComment.isEmpty()) {
+            return ResponseEntity
+                    .status(HttpStatus.NOT_FOUND)
+                    .body(CustomAPIResponse.createFailWithoutData(HttpStatus.NOT_FOUND.value(), "해당하는 댓글이 존재하지 않습니다."));
+        }
+
+        User user = userRepository.findById(req.getUserId()).orElseThrow();
+        Comment comment = optionalComment.get();
+
+        //dislikes 스키마에 user_id, comment_id를 가지는 레코드 추가
+        Dislikes dislikes = req.toEntity(user, comment);
+        dislikesRepository.save(dislikes);
+
+        //Comment 스키마에 dislikes_count + 1
+        int dislikesCount = comment.getDislikeCount() + 1;
+        comment.changeDislikeCount(dislikesCount);
+        commentRepository.save(comment); // 변경 사항 저장
+
+        //싫어요 추가 성공 : 200
+        CustomAPIResponse<?> res = CustomAPIResponse.createSuccessWithoutData(HttpStatus.OK.value(), "해당 댓글을 싫어요 하셨습니다.");
         return ResponseEntity.ok(res);
     }
 }

--- a/yourside/src/main/java/com/likelion/yourside/dislikes/DislikesRepository.java
+++ b/yourside/src/main/java/com/likelion/yourside/dislikes/DislikesRepository.java
@@ -1,0 +1,9 @@
+package com.likelion.yourside.dislikes;
+
+import com.likelion.yourside.domain.Dislikes;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DislikesRepository extends JpaRepository<Dislikes, Long> {
+}

--- a/yourside/src/main/java/com/likelion/yourside/domain/Comment.java
+++ b/yourside/src/main/java/com/likelion/yourside/domain/Comment.java
@@ -29,4 +29,8 @@ public class Comment extends BaseEntity {
     public void changeLikeCount(int likeCount) {
         this.likeCount = likeCount;
     }
+    public void changeDislikeCount(int dislikeCount) {
+        this.dislikeCount = dislikeCount;
+    }
+
 }


### PR DESCRIPTION
### 🌈 Issue 번호
- close #86 

### 📄 변경 사항
1. 댓글 싫어요 추가 API 개발
2. 피드백 받은 댓글 작성 부분 수정
- PathVariable ->RequestBody
  
### 🏆 테스트 결과
ex) API의 경우 명세서에 기재된 사항들 Postman으로 테스트한 결과 첨부
1. 댓글 싫어요 추가 API 개발
- 200(성공)
![image](https://github.com/HSU-Likelion12-yourSide/YourSide-Server/assets/147326233/c8ee338d-06bf-45cf-9fba-e79b3e14aeeb)

- 404(댓글 찾을 수 없음)
![image](https://github.com/HSU-Likelion12-yourSide/YourSide-Server/assets/147326233/063a586b-0980-434b-9396-8f83856131e9)

2. 피드백 받은 댓글 작성 부분 수정
- 제대로 작동 함 
![image](https://github.com/HSU-Likelion12-yourSide/YourSide-Server/assets/147326233/bd0745e3-38aa-4315-b0b7-0eba097bb7d1)


**_-> 댓글 좋아요/싫어요 추가/삭제 시 게시글을 찾을 수 없는 경우에 대한 예외처리 추가할 예정_**