### PR TITLE
🚨 [Fix] 게시글/댓글 반환값에 id 포함

### DIFF
--- a/yourside/src/main/java/com/likelion/yourside/comment/dto/CommentListResponseDto.java
+++ b/yourside/src/main/java/com/likelion/yourside/comment/dto/CommentListResponseDto.java
@@ -11,6 +11,7 @@ public class CommentListResponseDto {
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     @AllArgsConstructor
     public static class CommentResponse {
+        private Long id;
         private String nickname;
         @JsonProperty("created_at")
         private String createdAt;

--- a/yourside/src/main/java/com/likelion/yourside/comment/service/CommentServiceImpl.java
+++ b/yourside/src/main/java/com/likelion/yourside/comment/service/CommentServiceImpl.java
@@ -97,6 +97,7 @@ public class CommentServiceImpl implements CommentService{
             Optional<Dislikes> foundDislikes = dislikesRepository.findByUserAndComment(user, comment);
 
             commentResponses.add(CommentListResponseDto.CommentResponse.builder()
+                    .id(comment.getId())
                     .nickname(user.getNickname())
                     .createdAt(comment.localDateTimeToString())
                     .content(comment.getContent())

--- a/yourside/src/main/java/com/likelion/yourside/posting/dto/PostingListDto.java
+++ b/yourside/src/main/java/com/likelion/yourside/posting/dto/PostingListDto.java
@@ -10,6 +10,7 @@ public class PostingListDto {
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     @AllArgsConstructor
     public static class PostingResponse {
+        private Long id;
         private String title;
         private String content;
         @JsonProperty("created_at")

--- a/yourside/src/main/java/com/likelion/yourside/posting/service/PostingServiceImpl.java
+++ b/yourside/src/main/java/com/likelion/yourside/posting/service/PostingServiceImpl.java
@@ -207,6 +207,7 @@ public class PostingServiceImpl implements PostingService{
         List<PostingListDto.PostingResponse> postingListResponseDtos = new ArrayList<>();
         for (Posting posting : postings) {
             postingListResponseDtos.add(PostingListDto.PostingResponse.builder()
+                            .id(posting.getId())
                             .title(posting.getTitle())
                             .content(posting.getContent())
                             .createdAt(posting.localDateTimeToString())


### PR DESCRIPTION
### 🌈 Issue 번호
- close #127 

### 📄 변경 사항
<img width="569" alt="image" src="https://github.com/user-attachments/assets/7f2ec374-90b1-4afa-9dda-c8ac32127b37">
<img width="551" alt="image" src="https://github.com/user-attachments/assets/83ad0f64-4685-4c78-8ef0-5d4eafc379d7">


### 🏆 테스트 결과
ex) API의 경우 명세서에 기재된 사항들 Postman으로 테스트한 결과 첨부
